### PR TITLE
fix(attendance): auto focus nfc tag field

### DIFF
--- a/tgctm/ctm/templates/register_attendance.html
+++ b/tgctm/ctm/templates/register_attendance.html
@@ -11,11 +11,17 @@
 
 <form method="post" class="form">
     {% csrf_token %}
-  
+
     {% bootstrap_form form %}
-  
+
     {% bootstrap_button button_type="submit" content="Save" %}
-      
-  </form>
+</form>
+
+<script>
+  // auto select nfc tag field
+  window.onload = function() {
+    document.getElementById("id_nfc_tag").focus();
+  };
+</script>
 
 {%endblock%}


### PR DESCRIPTION
This makes the NFC tag field focused when loading the page, to support NFC scanners.

![image](https://user-images.githubusercontent.com/10573728/227242329-248c2408-1972-4f0d-9a19-4bcaa298b7b0.png)
